### PR TITLE
feat: handle mult overflow when formatting centuries

### DIFF
--- a/configure
+++ b/configure
@@ -7551,11 +7551,11 @@ fi
 
 # supply -g if --enable-debug
 if test "$enable_debug" = yes && test "$ac_cv_prog_cc_g" = yes; then
-  CFLAGS="$CFLAGS -g"
+  CFLAGS="$CFLAGS -g -ftrapv"
 fi
 
 if test "$enable_debug" = yes && test "$ac_cv_prog_cxx_g" = yes; then
-  CXXFLAGS="$CXXFLAGS -g"
+  CXXFLAGS="$CXXFLAGS -g -ftrapv"
 fi
 
 # enable code coverage if --enable-coverage

--- a/configure
+++ b/configure
@@ -7551,11 +7551,11 @@ fi
 
 # supply -g if --enable-debug
 if test "$enable_debug" = yes && test "$ac_cv_prog_cc_g" = yes; then
-  CFLAGS="$CFLAGS -g -ftrapv"
+  CFLAGS="$CFLAGS -g"
 fi
 
 if test "$enable_debug" = yes && test "$ac_cv_prog_cxx_g" = yes; then
-  CXXFLAGS="$CXXFLAGS -g -ftrapv"
+  CXXFLAGS="$CXXFLAGS -g"
 fi
 
 # enable code coverage if --enable-coverage

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4839,15 +4839,29 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
 		/* use first year of century */
 		if (tmfc.bc)
 			tmfc.cc = -tmfc.cc;
-
-        if (tmfc.cc >= 0)
-            tmfc.cc -= 1;
-
-        if(pg_mul_s32_overflow(tmfc.cc, 100, &tmfc.cc) || pg_add_s32_overflow(tmfc.cc, 1, &tm->tm_year)) {
-            ereport(ERROR,
-                    (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
-                            errmsg("date out of range: \"%s\"",
-                                   text_to_cstring(date_txt))));
+        if (tmfc.cc >= 0) {
+            /* +1 because 21st century started in 2001 */
+            /* tm->tm_year = (tmfc.cc - 1) * 100 + 1; */
+            if (pg_mul_s32_overflow((tmfc.cc - 1), 100, &tm->tm_year) ||
+            pg_add_s32_overflow(tm->tm_year, 1, &tm->tm_year))
+            {
+                ereport(ERROR,
+                        (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+                                errmsg("date out of range: \"%s\"",
+                                       text_to_cstring(date_txt))));
+            }
+        }
+        else {
+            /* +1 because year == 599 is 600 BC */
+            /* tm->tm_year = tmfc.cc * 100 + 1; */
+            if (pg_mul_s32_overflow(tmfc.cc, 100, &tm->tm_year) ||
+            pg_add_s32_overflow(tm->tm_year, 1, &tm->tm_year))
+            {
+                ereport(ERROR,
+                        (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+                                errmsg("date out of range: \"%s\"",
+                                       text_to_cstring(date_txt))));
+            }
         }
 
         fmask |= DTK_M(YEAR);

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4849,6 +4849,7 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
                             errmsg("date out of range: \"%s\"",
                                    text_to_cstring(date_txt))));
         }
+
         fmask |= DTK_M(YEAR);
 	}
 

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -77,6 +77,7 @@
 
 #include "catalog/pg_collation.h"
 #include "catalog/pg_type.h"
+#include "common/int.h"
 #include "common/unicode_case.h"
 #include "common/unicode_category.h"
 #include "mb/pg_wchar.h"
@@ -4838,12 +4839,19 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
 		/* use first year of century */
 		if (tmfc.bc)
 			tmfc.cc = -tmfc.cc;
+
+        int64 value;
+        if (tmfc.cc >= 0)
+            tmfc.cc -= 1;
+
+        pg_mul_s64_overflow(tmfc.cc, 100, &value);
+
 		if (tmfc.cc >= 0)
 			/* +1 because 21st century started in 2001 */
-			tm->tm_year = (tmfc.cc - 1) * 100 + 1;
+			tm->tm_year = value + 1;
 		else
 			/* +1 because year == 599 is 600 BC */
-			tm->tm_year = tmfc.cc * 100 + 1;
+			tm->tm_year = value + 1;
 		fmask |= DTK_M(YEAR);
 	}
 

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4850,6 +4850,7 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
                                    text_to_cstring(date_txt))));
         }
 
+
         fmask |= DTK_M(YEAR);
 	}
 

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4840,19 +4840,17 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
 		if (tmfc.bc)
 			tmfc.cc = -tmfc.cc;
 
-        int64 value;
         if (tmfc.cc >= 0)
             tmfc.cc -= 1;
 
-        pg_mul_s64_overflow(tmfc.cc, 100, &value);
+        if(pg_mul_s32_overflow(tmfc.cc, 100, &tmfc.cc) || pg_add_s32_overflow(tmfc.cc, 1, &tm->tm_year)) {
+            ereport(ERROR,
+                    (errcode(ERRCODE_DATETIME_VALUE_OUT_OF_RANGE),
+                            errmsg("date out of range: \"%s\"",
+                                   text_to_cstring(date_txt))));
+        }
 
-		if (tmfc.cc >= 0)
-			/* +1 because 21st century started in 2001 */
-			tm->tm_year = value + 1;
-		else
-			/* +1 because year == 599 is 600 BC */
-			tm->tm_year = value + 1;
-		fmask |= DTK_M(YEAR);
+        fmask |= DTK_M(YEAR);
 	}
 
 	if (tmfc.j)

--- a/src/backend/utils/adt/formatting.c
+++ b/src/backend/utils/adt/formatting.c
@@ -4849,8 +4849,6 @@ do_to_timestamp(text *date_txt, text *fmt, Oid collid, bool std,
                             errmsg("date out of range: \"%s\"",
                                    text_to_cstring(date_txt))));
         }
-
-
         fmask |= DTK_M(YEAR);
 	}
 

--- a/src/test/modules/test_json_parser/test_json_parser_incremental.c
+++ b/src/test/modules/test_json_parser/test_json_parser_incremental.c
@@ -124,7 +124,7 @@ main(int argc, char **argv)
 	makeJsonLexContextIncremental(&lex, PG_UTF8, need_strings);
 	initStringInfo(&json);
 
-	if ((json_file = fopen(testfile, "r")) == NULL)
+	if ((json_file = fopen(testfile, PG_BINARY_R)) == NULL)
 		pg_fatal("error opening input: %m");
 
 	if (fstat(fileno(json_file), &statbuf) != 0)

--- a/src/test/modules/test_json_parser/test_json_parser_perf.c
+++ b/src/test/modules/test_json_parser/test_json_parser_perf.c
@@ -55,7 +55,7 @@ main(int argc, char **argv)
 
 	sscanf(argv[1], "%d", &iter);
 
-	if ((json_file = fopen(argv[2], "r")) == NULL)
+	if ((json_file = fopen(argv[2], PG_BINARY_R)) == NULL)
 		pg_fatal("Could not open input file '%s': %m", argv[2]);
 
 	while ((n_read = fread(buff, 1, 6000, json_file)) > 0)

--- a/src/test/regress/expected/horology.out
+++ b/src/test/regress/expected/horology.out
@@ -3778,6 +3778,9 @@ SELECT to_date('0000-02-01','YYYY-MM-DD');  -- allowed, though it shouldn't be
  02-01-0001 BC
 (1 row)
 
+SELECT to_date('100000000', 'CC');
+ERROR:  date out of range: "100000000"
+
 -- to_char's TZ format code produces zone abbrev if known
 SELECT to_char('2012-12-12 12:00'::timestamptz, 'YYYY-MM-DD HH:MI:SS TZ');
          to_char         

--- a/src/test/regress/expected/horology.out
+++ b/src/test/regress/expected/horology.out
@@ -3780,7 +3780,6 @@ SELECT to_date('0000-02-01','YYYY-MM-DD');  -- allowed, though it shouldn't be
 
 SELECT to_date('100000000', 'CC');
 ERROR:  date out of range: "100000000"
-
 -- to_char's TZ format code produces zone abbrev if known
 SELECT to_char('2012-12-12 12:00'::timestamptz, 'YYYY-MM-DD HH:MI:SS TZ');
          to_char         

--- a/src/test/regress/sql/horology.sql
+++ b/src/test/regress/sql/horology.sql
@@ -660,6 +660,7 @@ SELECT to_date('2016 365', 'YYYY DDD');  -- ok
 SELECT to_date('2016 366', 'YYYY DDD');  -- ok
 SELECT to_date('2016 367', 'YYYY DDD');
 SELECT to_date('0000-02-01','YYYY-MM-DD');  -- allowed, though it shouldn't be
+SELECT to_date('100000000', 'CC');
 
 -- to_char's TZ format code produces zone abbrev if known
 SELECT to_char('2012-12-12 12:00'::timestamptz, 'YYYY-MM-DD HH:MI:SS TZ');


### PR DESCRIPTION
Fixes a trap-producing case with date types: `SELECT to_date('100000000', 'CC');`